### PR TITLE
Fix import style in graph_loader (v0.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Query system Cypher syntax bug** - Fixed `find-dead-code` query using SQL syntax instead of Cypher
   - Changed `f.name NOT IN [...]` to `NOT f.name IN [...]` (line 40 in dead_code.py)
   - Would fail with "Invalid input 'NOT'" error when executed against Neo4j
+- **Import style violation in graph_loader** - Fixed to follow CLAUDE.md standards
+  - Changed `from mapper.graph import NodeLabel, RelationshipType` to `from mapper import graph`
+  - Updated all references to use `graph.NodeLabel` and `graph.RelationshipType`
+  - Aligns with Python style guide: import modules, not classes
 
 ### Added
 - **Query execution integration tests** - 10 new tests validating queries against real Neo4j

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mapper (Application Mapper)
 
-![Version](https://img.shields.io/badge/version-0.7.2-blue.svg)
+![Version](https://img.shields.io/badge/version-0.7.3-blue.svg)
 ![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ydkadri/9501806ed5eac873dd324bc606c6dd79/raw/mapper-tests.json&cacheSeconds=300)
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ydkadri/9501806ed5eac873dd324bc606c6dd79/raw/mapper-coverage.json&cacheSeconds=300)
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mapper"
-version = "0.7.2"
+version = "0.7.3"
 description = "Mapper (Application Mapper) - AST-based Python code analyzer with Neo4j graph storage"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -93,7 +93,7 @@ addopts = [
 testpaths = ["tests"]
 
 [tool.bumpversion]
-current_version = "0.7.2"
+current_version = "0.7.3"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/src/mapper/__init__.py
+++ b/src/mapper/__init__.py
@@ -18,7 +18,7 @@ from mapper.graph import Neo4jConnection
 from mapper.graph_loader import GraphLoader
 from mapper.name_resolver import NameResolver, UnresolvedName
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 __all__ = [
     # Version

--- a/src/mapper/graph_loader/loader.py
+++ b/src/mapper/graph_loader/loader.py
@@ -139,7 +139,9 @@ class GraphLoader:
                             from_id, to_id, graph.RelationshipType.INHERITS
                         )
                     case "calls":
-                        self.connection.create_relationship(from_id, to_id, graph.RelationshipType.CALLS)
+                        self.connection.create_relationship(
+                            from_id, to_id, graph.RelationshipType.CALLS
+                        )
                     case "imports":
                         self.connection.create_relationship(
                             from_id, to_id, graph.RelationshipType.IMPORTS

--- a/src/mapper/graph_loader/loader.py
+++ b/src/mapper/graph_loader/loader.py
@@ -1,7 +1,6 @@
 """Graph loader implementation."""
 
 from mapper import ast_parser, graph
-from mapper.graph import NodeLabel, RelationshipType
 
 
 class GraphLoader:
@@ -57,7 +56,7 @@ class GraphLoader:
             class_node_id = self._create_class_node(class_info, class_fqn)
             # DEFINES relationship: Module defines Class
             self.connection.create_relationship(
-                module_node_id, class_node_id, RelationshipType.DEFINES
+                module_node_id, class_node_id, graph.RelationshipType.DEFINES
             )
 
             # Create methods within class
@@ -66,7 +65,7 @@ class GraphLoader:
                 method_node_id = self._create_function_node(method, method_fqn, is_method=True)
                 # CONTAINS relationship: Class contains Method
                 self.connection.create_relationship(
-                    class_node_id, method_node_id, RelationshipType.CONTAINS
+                    class_node_id, method_node_id, graph.RelationshipType.CONTAINS
                 )
 
                 # Track method calls for later
@@ -85,7 +84,7 @@ class GraphLoader:
             func_node_id = self._create_function_node(func_info, func_fqn)
             # DEFINES relationship: Module defines Function
             self.connection.create_relationship(
-                module_node_id, func_node_id, RelationshipType.DEFINES
+                module_node_id, func_node_id, graph.RelationshipType.DEFINES
             )
 
             # Track function calls for later
@@ -137,21 +136,21 @@ class GraphLoader:
                 match rel_type:
                     case "inherits":
                         self.connection.create_relationship(
-                            from_id, to_id, RelationshipType.INHERITS
+                            from_id, to_id, graph.RelationshipType.INHERITS
                         )
                     case "calls":
-                        self.connection.create_relationship(from_id, to_id, RelationshipType.CALLS)
+                        self.connection.create_relationship(from_id, to_id, graph.RelationshipType.CALLS)
                     case "imports":
                         self.connection.create_relationship(
-                            from_id, to_id, RelationshipType.IMPORTS
+                            from_id, to_id, graph.RelationshipType.IMPORTS
                         )
                     case "from_module":
                         self.connection.create_relationship(
-                            from_id, to_id, RelationshipType.FROM_MODULE
+                            from_id, to_id, graph.RelationshipType.FROM_MODULE
                         )
                     case "depends_on":
                         self.connection.create_relationship(
-                            from_id, to_id, RelationshipType.DEPENDS_ON
+                            from_id, to_id, graph.RelationshipType.DEPENDS_ON
                         )
                     case _:
                         raise ValueError(f"Unknown relationship type: {rel_type}")
@@ -165,7 +164,7 @@ class GraphLoader:
                         external_node_id = existing_id
                     else:
                         external_node_id = self.connection.create_node(
-                            NodeLabel.MODULE,
+                            graph.NodeLabel.MODULE,
                             {"name": to_name, "package": to_name, "is_external": True},
                         )
 
@@ -175,11 +174,11 @@ class GraphLoader:
                 match rel_type:
                     case "from_module":
                         self.connection.create_relationship(
-                            from_id, external_node_id, RelationshipType.FROM_MODULE
+                            from_id, external_node_id, graph.RelationshipType.FROM_MODULE
                         )
                     case "depends_on":
                         self.connection.create_relationship(
-                            from_id, external_node_id, RelationshipType.DEPENDS_ON
+                            from_id, external_node_id, graph.RelationshipType.DEPENDS_ON
                         )
                     case _:
                         raise ValueError(f"Unknown relationship type: {rel_type}")
@@ -239,7 +238,7 @@ class GraphLoader:
         if module.docstring:
             properties["docstring"] = module.docstring
 
-        node_id = self.connection.create_node(NodeLabel.MODULE, properties)
+        node_id = self.connection.create_node(graph.NodeLabel.MODULE, properties)
         self._node_ids[fqn] = node_id
         return node_id
 
@@ -264,7 +263,7 @@ class GraphLoader:
         if class_info.bases:
             properties["bases"] = str(class_info.bases)  # Serialize for now
 
-        node_id = self.connection.create_node(NodeLabel.CLASS, properties)
+        node_id = self.connection.create_node(graph.NodeLabel.CLASS, properties)
         self._node_ids[fqn] = node_id
         return node_id
 
@@ -281,7 +280,7 @@ class GraphLoader:
         Returns:
             Node ID for created function
         """
-        label = NodeLabel.METHOD if is_method else NodeLabel.FUNCTION
+        label = graph.NodeLabel.METHOD if is_method else graph.NodeLabel.FUNCTION
         properties = {
             "name": func_info.name,
             "fqn": fqn,
@@ -329,11 +328,11 @@ class GraphLoader:
         if submodule_path:
             properties["submodule_path"] = submodule_path
 
-        import_node_id = self.connection.create_node(NodeLabel.IMPORT, properties)
+        import_node_id = self.connection.create_node(graph.NodeLabel.IMPORT, properties)
 
         # Create Module -[IMPORTS]-> Import relationship
         self.connection.create_relationship(
-            module_node_id, import_node_id, RelationshipType.IMPORTS
+            module_node_id, import_node_id, graph.RelationshipType.IMPORTS
         )
 
         # Track deferred FROM_MODULE relationship to external module


### PR DESCRIPTION
## Summary

Fixes import style violation in `graph_loader/loader.py` to follow CLAUDE.md Python style standards.

Part of v0.7.3 code quality improvements.

## Changes

### Fixed
- **Import style in graph_loader** (#67 - partial)
  - Changed `from mapper.graph import NodeLabel, RelationshipType`
  - To: `from mapper import graph` (already present)
  - Updated all references: `NodeLabel` → `graph.NodeLabel`, `RelationshipType` → `graph.RelationshipType`
  - Aligns with `docs/contributing/python-style.md`: "Import the module, not individual classes/functions"

### Deferred
- **Import style in `__init__.py`** - Deferred to v0.7.5
  - Public API changes should be handled together with #71 (minimize public API exports)
  - Prevents breaking changes for users importing classes directly

## Version

Bumps version from `0.7.2` → `0.7.3`

This release includes:
1. Query system Cypher bug fix (merged in PR #75)
2. Query execution integration tests (merged in PR #75)
3. Import style fix in graph_loader (this PR)

## Testing

- ✅ All 212 tests passing
- ✅ Ruff linting clean  
- ✅ mypy type checking clean
- ✅ No functionality changes - pure refactor

## Checklist

- [x] Import style fixed to follow CLAUDE.md standards
- [x] All references updated throughout file
- [x] CHANGELOG.md updated
- [x] Version bumped to 0.7.3
- [x] All tests passing
- [x] Linting and type checking clean

## Next

After this merges:
- v0.7.4: Exception handling + Protocol naming (#68, #69)
- v0.7.5: OutputFormat enum + Public API minimization (#70, #71, deferred #67)

🤖 Generated with [Claude Code](https://claude.com/claude-code)