### PR TITLE
Add GitHub issue tracking to development workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ Work happens in phases with explicit checkpoints for early alignment.
    
    **PR Strategy**: Single PR | Multiple smaller PRs
    
+   **GitHub Issues**: #XX, #YY (list all issues this work will resolve)
+   
    **Commit Structure**:
    1. [Self-contained unit 1] - what and why
    2. [Self-contained unit 2] - what and why
@@ -137,6 +139,8 @@ Work happens in phases with explicit checkpoints for early alignment.
    - Design patterns used
    - Integration points
    ```
+   
+   **IMPORTANT**: Check ROADMAP.md for any existing GitHub issues related to this feature. List them in the plan so they can be referenced in the PR and closed on merge.
 
 **CHECKPOINT 3**: Push plan to ROADMAP.md
 - **Request review**: "Implementation plan complete - agreeing on commit structure and milestones"
@@ -195,7 +199,12 @@ Work happens in phases with explicit checkpoints for early alignment.
    - Ensure each commit is self-contained and logical
    - Verify all tests pass after rebase
 
-10. **Mark PR ready for final review**
+10. **Verify GitHub issue references**:
+    - Check ROADMAP.md implementation plan for listed GitHub issues
+    - Add issue references to PR description (e.g., "Closes #33, Resolves #42")
+    - Verify issue numbers are correct and still open
+
+11. **Mark PR ready for final review**
     - **Request review**: "Ready for final review - all feedback addressed, tests passing, docs updated"
     - Wait for CI to pass (use `gh pr view <number> --json statusCheckRollup`)
 
@@ -368,9 +377,9 @@ just mapper [args]    # Run CLI tool
 **Phases with checkpoints:**
 1. **Align** → User journey doc → Request review
 2. **Design** → Interface docs → Request review  
-3. **Plan** → Implementation plan in ROADMAP.md → Request review
+3. **Plan** → Implementation plan in ROADMAP.md (list GitHub issues) → Request review
 4. **Implement** → Code according to plan → Request review at milestones
-5. **Finalize** → Self-validate, update docs, bump version, rebase → Mark ready
+5. **Finalize** → Self-validate, update docs, bump version, rebase, verify issue refs → Mark ready
 
 **Before each push:**
 - Run `just lint` to catch style issues
@@ -382,6 +391,7 @@ just mapper [args]    # Run CLI tool
 - All docs updated (CHANGELOG, README, technical docs)
 - Clean commit history (rebase/squash fixups)
 - Version bumped
+- GitHub issues verified and referenced in PR (check ROADMAP.md plan)
 
 ---
 


### PR DESCRIPTION
## Summary

Update CLAUDE.md development workflow to ensure GitHub issues are tracked and closed when work is completed.

## Changes

**Phase 3 (Plan Implementation)**:
- Added 'GitHub Issues' field to implementation plan template in ROADMAP.md
- Added instruction to check ROADMAP.md for existing issues related to feature
- Ensures issues are identified during planning phase

**Phase 5 (Finalize)**:
- Added step 10: Verify GitHub issue references before marking PR ready
- Check ROADMAP.md implementation plan for listed issues
- Add issue references to PR description (e.g., "Closes #33, Resolves #42")
- Verify issue numbers are correct and still open

**Quick Reference section**:
- Updated phase 3 summary to include "(list GitHub issues)"
- Updated phase 5 summary to include "verify issue refs"
- Added "GitHub issues verified and referenced in PR" to "Before marking ready" checklist

## Impact

This prevents forgetting to close resolved GitHub issues when PRs merge. We'll now:
1. Identify relevant issues during planning (Phase 3)
2. Reference them in PR descriptions (Phase 5)
3. Have them automatically closed when PR merges

## Test Plan

- [x] CLAUDE.md updated with clear instructions
- [x] Changes committed and pushed
- [ ] Review workflow documentation for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)